### PR TITLE
SDK26に更新した影響による、Android 8.0以降の通知処理の修正。( #32 )

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        applicationId "org.bitbucket.snaoto22.frock"
-        minSdkVersion 23
+        applicationId "com.github.nsaito92.Frock"
+        minSdkVersion 26
         targetSdkVersion 26
         versionCode 2
         versionName "1.1"
@@ -25,7 +25,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.4.0'
+    compile 'com.android.support:appcompat-v7:26.0.0'
 
     implementation "com.google.code.gson:gson:2.8.5"
 }

--- a/app/src/main/java/com/example/naotosaito/clocktest/AlarmService.java
+++ b/app/src/main/java/com/example/naotosaito/clocktest/AlarmService.java
@@ -60,8 +60,8 @@ public class AlarmService extends Service {
             audioPlay(intent.getIntExtra("COLUMN_INDEX_ID", 0));
 
             // 通知を表示する
-            NotificationManagerController controller = new NotificationManagerController(MyApplication.getContext());
-            controller.createNotificationAlarmRinging();
+            NotificationManagerController notificationManagerController = new NotificationManagerController(MyApplication.getContext());
+            notificationManagerController.createNotificationAlarmRinging();
 
             // アラーム鳴動通知ダイアログを表示
             Intent intent_alarmdialogactivity = new Intent(this, CallAlarmDialogActivity.class);

--- a/app/src/main/java/com/example/naotosaito/clocktest/NotificationManagerController.java
+++ b/app/src/main/java/com/example/naotosaito/clocktest/NotificationManagerController.java
@@ -1,11 +1,14 @@
 package com.example.naotosaito.clocktest;
 
 import android.app.Notification;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.support.v7.app.NotificationCompat;
+import android.os.Build;
+import android.support.v4.app.NotificationCompat;
+import android.util.Log;
 
 /**
  * NotificationManagerを使用するクラス
@@ -13,10 +16,12 @@ import android.support.v7.app.NotificationCompat;
  */
 
 class NotificationManagerController {
+    private final String TAG = NotificationManagerController.class.getSimpleName();
     private Context mContext = null;
     private NotificationManager manager;
 
     public NotificationManagerController(Context context) {
+        Log.d(TAG, "");
         // NotificationManagerでNotificationを表示
         // contextを経由してインスタンス取得
         mContext = context;
@@ -27,22 +32,37 @@ class NotificationManagerController {
     public class NotificationID {
         final static int ALARMRINGING = 0;
         final static int SNOOZE = 1;
+
+        final static int DEBUG = 100;
+    }
+
+    // Notification Channel ID
+    public class NotificationChannelID {
+        final static String ALARMRINGING = "0";
     }
 
     /**
      * アラーム鳴動中の通知を生成する
      */
     public void createNotificationAlarmRinging() {
+        Log.d(TAG, "createNotificationAlarmRinging");
+
+        // Android 8.0以降で必要な通知チャンネルの生成。未精製の場合、生成する。
+        createNotificationChannel(
+                NotificationChannelID.ALARMRINGING,
+                mContext.getString(R.string.channel_name_alarmringing),
+                manager.IMPORTANCE_DEFAULT);
+
         // 通知をタップした時のPendingIntent生成
         Intent intent_MainActivity = new Intent(mContext, MainActivity.class);
         PendingIntent pendingintent = PendingIntent.getActivity(
-                MyApplication.getContext(),
+                mContext,
                 ClockUtil.PendingIntentRequestCode.ALARM_NOTIFICATION,
                 intent_MainActivity,
                 PendingIntent.FLAG_CANCEL_CURRENT);
 
         // Notification生成
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(mContext);
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(mContext, NotificationChannelID.ALARMRINGING);
         Notification notification = builder
                 .setWhen(System.currentTimeMillis())
                 .setContentTitle("アラーム鳴動中")
@@ -59,10 +79,18 @@ class NotificationManagerController {
      * スヌーズが動作中の通知を生成する
      */
     public void createNotificationSnooze() {
+        Log.d(TAG, "createNotificationSnooze");
+
+        // Android 8.0以降で必要な通知チャンネルの生成。未精製の場合、生成する。
+        createNotificationChannel(
+                NotificationChannelID.ALARMRINGING,
+                mContext.getString(R.string.channel_name_alarmringing),
+                manager.IMPORTANCE_DEFAULT);
+
         // 通知をタップした時のPendingIntent生成
         Intent intent_MainActivity = new Intent(mContext, MainActivity.class);
         PendingIntent pendingintent = PendingIntent.getActivity(
-                MyApplication.getContext(),
+                mContext,
                 ClockUtil.PendingIntentRequestCode.NOTIFICATION_SNOOZE,
                 intent_MainActivity,
                 PendingIntent.FLAG_CANCEL_CURRENT);
@@ -72,14 +100,14 @@ class NotificationManagerController {
         actionIntent.setAction(ClockUtil.BroadCast.SNOOZE_FINISH);
 
         PendingIntent actionButtonIntent = PendingIntent.getBroadcast(
-                MyApplication.getContext(),
+                mContext,
                 ClockUtil.PendingIntentRequestCode.SNOOZE_FINISH,
                 actionIntent,
                 0
         );
 
         // Notification生成
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(mContext);
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(mContext, NotificationChannelID.ALARMRINGING);
         Notification notification = builder
                 .setWhen(System.currentTimeMillis())
                 .setContentTitle("スヌーズ動作中")
@@ -98,7 +126,37 @@ class NotificationManagerController {
      * @param id
      */
     public void notificationCansel(int id) {
+        Log.d(TAG, "notificationCansel");
+
         NotificationManager manager = (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
         manager.cancel(id);
+    }
+
+    /**
+     * Android 8.0以降で必要な通知チャンネルの生成処理
+     * @param id
+     */
+    private void createNotificationChannel(String id, CharSequence name, int importance) {
+        Log.d(TAG, "createNotificationChannel");
+
+        if (id == null || name == null) {
+            return;
+        }
+
+        // 渡されたIDのチャンネルが生成済みだった場合は、return。
+        if (manager.getNotificationChannel(id) != null) {
+            return;
+        }
+        // 端末OSverが、8.0未満の場合はreturn。
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return;
+        }
+
+        // NotificationChannelの初期化
+        NotificationChannel channel = new NotificationChannel(
+                id, name, importance);
+
+        // チャンネル生成実行
+        manager.createNotificationChannel(channel);
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,11 @@
         <item>土曜日</item>
     </string-array>
 
+    <!-- Notification -->
+    <string name="channel_name_alarmringing">アラーム鳴動中</string>
+
+
+
     <!-- etc -->
 
 </resources>


### PR DESCRIPTION
* SDKバージョンを上げないと、Android 8.0向け通知生成処理が実装出来ないため、26に更新。
* アラーム鳴動中の通知チャンネルが存在していなかった場合は、生成する処理を追加。
