### PR TITLE
ストレージ権限のランタイム要求処理を追加。他一部修正。( #33 )

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,16 +20,20 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".AlarmPreferenceActivity"></activity>
         <activity
-            android:name=".AlarmPreferenceActivity">
-        </activity>
-        <activity
-            android:name="com.example.naotosaito.clocktest.CallAlarmDialogActivity"
+            android:name=".CallAlarmDialogActivity"
+            android:launchMode="singleInstance"
             android:theme="@style/DialogTheme">
             <intent-filter>
                 <action android:name="org.bitbucket.snaoto22.frock.CALL_ALARMDIALOG_FINISH"></action>
             </intent-filter>
         </activity>
+        <activity
+            android:name=".PermissionDescriptionActivity"
+            android:launchMode="standard"
+            android:exported="false"
+            android:theme="@style/DialogTheme"></activity>
 
         <receiver
             android:name=".AlarmBroadcastReceiver"

--- a/app/src/main/java/com/example/naotosaito/clocktest/AlarmServiceSetter.java
+++ b/app/src/main/java/com/example/naotosaito/clocktest/AlarmServiceSetter.java
@@ -78,6 +78,10 @@ class AlarmServiceSetter {
             // スヌーズ回数の上限に達したため、カウントをリセット
             ClockUtil.setPrefInt("alarmservice", ClockUtil.SharedPreferencesKey.SNOOZE_COUNT, 0);
 
+            // 通知のキャンセル
+            NotificationManagerController notificationManagerController = new NotificationManagerController(MyApplication.getContext());
+            notificationManagerController.notificationCansel(NotificationManagerController.NotificationID.SNOOZE);
+
             // DBのクエリを叩いて、ONになっているアラーム設定を取得。
             FrockSettingsHelperController controller = new FrockSettingsHelperController();
             closestEntity = controller.getClosestCalender();

--- a/app/src/main/java/com/example/naotosaito/clocktest/CallAlarmDialogActivity.java
+++ b/app/src/main/java/com/example/naotosaito/clocktest/CallAlarmDialogActivity.java
@@ -79,7 +79,9 @@ public class CallAlarmDialogActivity extends AppCompatActivity {
         // アラーム鳴動中ダイアログの生成
         AlertDialog.Builder alertBuilder = new AlertDialog.Builder(this);
 
-        return alertBuilder.setTitle("アラーム鳴動中")
+        return alertBuilder.setTitle("Frock")
+                .setIcon(R.mipmap.ic_launcher)
+                .setMessage("アラーム鳴動中です")
                 .setCancelable(false)
                 .setPositiveButton("停止", new DialogInterface.OnClickListener() {
                     @Override

--- a/app/src/main/java/com/example/naotosaito/clocktest/ClockUtil.java
+++ b/app/src/main/java/com/example/naotosaito/clocktest/ClockUtil.java
@@ -55,6 +55,15 @@ public class ClockUtil {
         public static final String SNOOZE_FINISH = "org.bitbucket.snaoto22.frock.SNOOZE_FINISH";
     }
 
+
+    // Intent Key
+    public class IntentKey {
+        final static String PERMISSION_NAME = "PERMISSION_NAME";
+        final static String REASON = "REASON";
+        final static String PERMISSION = "PERMISSION";
+        final static String REQUEST_CODE = "REQUEST_CODE";
+    }
+
     // PackageName
     public class PackageNames {
         public static final String COM_ANDROID_EXTERNALSTORAGE_DOCUMENTS = "com.android.externalstorage.documents";

--- a/app/src/main/java/com/example/naotosaito/clocktest/NotificationManagerController.java
+++ b/app/src/main/java/com/example/naotosaito/clocktest/NotificationManagerController.java
@@ -127,8 +127,6 @@ class NotificationManagerController {
      */
     public void notificationCansel(int id) {
         Log.d(TAG, "notificationCansel");
-
-        NotificationManager manager = (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
         manager.cancel(id);
     }
 

--- a/app/src/main/java/com/example/naotosaito/clocktest/PermissionDescriptionActivity.java
+++ b/app/src/main/java/com/example/naotosaito/clocktest/PermissionDescriptionActivity.java
@@ -1,0 +1,105 @@
+package com.example.naotosaito.clocktest;
+
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v4.app.ActivityCompat;
+import android.support.v7.app.AlertDialog;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+
+/**
+ * 取得したい権限についての説明を行う画面。
+ */
+public class PermissionDescriptionActivity extends AppCompatActivity {
+
+    private static final String TAG = PermissionDescriptionActivity.class.getSimpleName();
+
+    /** ダイアログ  */
+    private AlertDialog dialog = null;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Log.d(TAG, "onCreate");
+
+        setContentView(R.layout.activity_permission_description);
+
+        // ダイアログに設定するパラメーターを取得して、ダイアログを生成。
+        Intent getIntent = getIntent();
+        if (getIntent != null) {
+            String permissionName = getIntent.getStringExtra(ClockUtil.IntentKey.PERMISSION_NAME);
+            String reason = getIntent.getStringExtra(ClockUtil.IntentKey.REASON);
+            String permission = getIntent.getStringExtra(ClockUtil.IntentKey.PERMISSION);
+            int requestCode = getIntent.getIntExtra(ClockUtil.IntentKey.REQUEST_CODE, -1);
+
+            // ダイアログ生成。
+            this.dialog = dialogCreate(permissionName,
+                    reason,
+                    permission,
+                    requestCode);
+        }
+
+        // ダイアログ表示失敗した場合は、Activity終了。
+        if (this.dialog == null) {
+            ClockUtil.ToastShow("権限説明画面の起動に失敗しました。");
+            PermissionDescriptionActivity.this.finish();
+        }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        Log.d(TAG, "onResume");
+
+        this.dialog.show();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        Log.d(TAG, "onDestroy");
+
+        if (this.dialog != null) {
+            this.dialog.dismiss();
+        }
+    }
+
+    /**
+     *  権限説明ダイアログオブジェクトを生成する。
+     * @return
+     */
+    private AlertDialog dialogCreate(String permissionName, String reason, String permission, int requestCode) {
+        Log.d(TAG, "dialogCreate");
+
+        // バリデーションチェック
+        if (permissionName == null || reason == null || permission == null) {
+            return null;
+        }
+
+        // アラーム鳴動中ダイアログの生成
+        AlertDialog.Builder alertBuilder = new AlertDialog.Builder(this);
+
+        return alertBuilder.setMessage("権限「" + permissionName + "」が付与されていません。" + "\n" + reason + "を行うために必要です。")
+                .setCancelable(false)
+                .setPositiveButton("付与する", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        // 権限要求処理を行う。
+                        ActivityCompat.requestPermissions(PermissionDescriptionActivity.this,
+                                new String[]{permission},
+                                requestCode);
+                        PermissionDescriptionActivity.this.finish();
+                    }
+                })
+                .setNeutralButton("付与しない", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick (DialogInterface dialog, int which) {
+
+                        // 何も処理を行わない。
+                        PermissionDescriptionActivity.this.finish();
+                    }
+                })
+                .create();
+    }
+}

--- a/app/src/main/res/layout/activity_permission_description.xml
+++ b/app/src/main/res/layout/activity_permission_description.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,8 @@
     <string name="time">時間</string>
     <string name="week">曜日</string>
     <string name="alarm_is_ringing">アラーム鳴動中</string>
+    <string name="storage">ストレージ</string>
+    <string name="reason_storage">内部ストレージのファイル参照</string>
 
     <string name="setting_delete">設定を削除</string>
     <string name="message_setting_delete">削除しますか?</string>


### PR DESCRIPTION
* 要求された権限についての説明を表示するActivityを新規作成。
* ファイラーアプリの起動は権限がある場合のみ行うように修正。
* アラーム実行開始時に、権限がある場合のみローカルファイルを参照するように修正。
* スヌーズ中の通知のキャンセル処理が漏れていたため修正。
* アラーム鳴動時のダイアログ生成処理のパラメーターを修正。
